### PR TITLE
Changed link color to match the lambda in the header

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -3,7 +3,7 @@
     <title>Haskell Toolbox - $title$</title>
     <style>
         a {
-            color: #02E6FF;
+            color: #F75500;
         }
     
         body {


### PR DESCRIPTION
The teal color is somewhat eye-straining (to me at least).  This updates the color to match the haskell logo and is, to me, a bit easier to read.
